### PR TITLE
Use alpine as base Docker image with custom user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.22 as build
 ARG version=unknown
 ARG hash=unknown
 WORKDIR /app
@@ -8,6 +8,8 @@ COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'github.com/conduktor/ctl/cmd.version=$version' -X 'github.com/conduktor/ctl/cmd.hash=$hash'" -o /conduktor . && rm -rf /app
 CMD ["/bin/conduktor"]
 
-FROM scratch
-COPY --from=0 /conduktor /bin/conduktor
+FROM alpine:3.19
+RUN adduser -D conduktor
+USER conduktor
+COPY --from=build /conduktor /bin/conduktor
 ENTRYPOINT ["/bin/conduktor"]


### PR DESCRIPTION
- Use alpine for base image to have basic tools installed and default certificates for https connections
- Create and use `conduktor` user inside image as security best practice