### PR TITLE
Set CDK-CLIENT header to improve analytics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           goversion: "${{ env.GO_VERSION }}"
-          ldflags: -X 'github.com/conduktor/ctl/cmd.version=${{ github.event.release.tag_name }}' -X 'github.com/conduktor/ctl/cmd.hash=${{ github.sha }}'
+          ldflags: -X 'github.com/conduktor/ctl/utils.version=${{ github.event.release.tag_name }}' -X 'github.com/conduktor/ctl/utils.hash=${{ github.sha }}'
           project_path: "./"
           binary_name: "conduktor"
 

--- a/client/client.go
+++ b/client/client.go
@@ -19,7 +19,7 @@ type Client struct {
 }
 
 func Make(token string, baseUrl string, debug bool, key, cert string) (*Client, error) {
-	restyClient := resty.New().SetDebug(debug).SetHeader("Authorization", "Bearer "+token)
+	restyClient := resty.New().SetDebug(debug).SetHeader("Authorization", "Bearer "+token).SetHeader("CDK-CLIENT", "CLI")
 	if (key == "" && cert != "") || (key != "" && cert == "") {
 		return nil, fmt.Errorf("key and cert must be provided together")
 	} else if key != "" && cert != "" {

--- a/client/client.go
+++ b/client/client.go
@@ -19,7 +19,7 @@ type Client struct {
 }
 
 func Make(token string, baseUrl string, debug bool, key, cert string) (*Client, error) {
-	restyClient := resty.New().SetDebug(debug).SetHeader("Authorization", "Bearer "+token).SetHeader("CDK-CLIENT", "CLI")
+	restyClient := resty.New().SetDebug(debug).SetHeader("Authorization", "Bearer "+token).SetHeader("CDK-CLIENT", "CLI/"+utils.GetConduktorVersion())
 	if (key == "" && cert != "") || (key != "" && cert == "") {
 		return nil, fmt.Errorf("key and cert must be provided together")
 	} else if key != "" && cert != "" {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -32,7 +32,7 @@ func TestApplyShouldWork(t *testing.T) {
 		"http://baseUrl/public/v1/topic",
 		nil,
 		httpmock.HeaderIs("Authorization", "Bearer "+token).
-			And(httpmock.HeaderIs("CDK-CLIENT", "CLI")).
+			And(httpmock.HeaderIs("CDK-CLIENT", "CLI/unknown")).
 			And(httpmock.BodyContainsBytes(topic.Json)),
 		responder,
 	)
@@ -143,7 +143,7 @@ func TestGetShouldWork(t *testing.T) {
 		"http://baseUrl/public/v1/application",
 		nil,
 		httpmock.HeaderIs("Authorization", "Bearer "+token).
-			And(httpmock.HeaderIs("CDK-CLIENT", "CLI")),
+			And(httpmock.HeaderIs("CDK-CLIENT", "CLI/unknown")),
 		responder,
 	)
 
@@ -265,7 +265,7 @@ func TestDescribeShouldWork(t *testing.T) {
 		"http://baseUrl/public/v1/application/yo",
 		nil,
 		httpmock.HeaderIs("Authorization", "Bearer "+token).
-			And(httpmock.HeaderIs("CDK-CLIENT", "CLI")),
+			And(httpmock.HeaderIs("CDK-CLIENT", "CLI/unknown")),
 		responder,
 	)
 
@@ -326,7 +326,7 @@ func TestDeleteShouldWork(t *testing.T) {
 		"http://baseUrl/public/v1/application/yo",
 		nil,
 		httpmock.HeaderIs("Authorization", "Bearer "+token).
-			And(httpmock.HeaderIs("CDK-CLIENT", "CLI")),
+			And(httpmock.HeaderIs("CDK-CLIENT", "CLI/unknown")),
 		responder,
 	)
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -32,6 +32,7 @@ func TestApplyShouldWork(t *testing.T) {
 		"http://baseUrl/public/v1/topic",
 		nil,
 		httpmock.HeaderIs("Authorization", "Bearer "+token).
+			And(httpmock.HeaderIs("CDK-CLIENT", "CLI")).
 			And(httpmock.BodyContainsBytes(topic.Json)),
 		responder,
 	)
@@ -141,7 +142,8 @@ func TestGetShouldWork(t *testing.T) {
 		"GET",
 		"http://baseUrl/public/v1/application",
 		nil,
-		httpmock.HeaderIs("Authorization", "Bearer "+token),
+		httpmock.HeaderIs("Authorization", "Bearer "+token).
+			And(httpmock.HeaderIs("CDK-CLIENT", "CLI")),
 		responder,
 	)
 
@@ -262,7 +264,8 @@ func TestDescribeShouldWork(t *testing.T) {
 		"GET",
 		"http://baseUrl/public/v1/application/yo",
 		nil,
-		httpmock.HeaderIs("Authorization", "Bearer "+token),
+		httpmock.HeaderIs("Authorization", "Bearer "+token).
+			And(httpmock.HeaderIs("CDK-CLIENT", "CLI")),
 		responder,
 	)
 
@@ -322,7 +325,8 @@ func TestDeleteShouldWork(t *testing.T) {
 		"DELETE",
 		"http://baseUrl/public/v1/application/yo",
 		nil,
-		httpmock.HeaderIs("Authorization", "Bearer "+token),
+		httpmock.HeaderIs("Authorization", "Bearer "+token).
+			And(httpmock.HeaderIs("CDK-CLIENT", "CLI")),
 		responder,
 	)
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/conduktor/ctl/utils"
 	"github.com/spf13/cobra"
 )
-
-var version = "unknown"
-var hash = "unknown"
 
 // versionCmd represents the apply command
 var versionCmd = &cobra.Command{
@@ -14,7 +12,7 @@ var versionCmd = &cobra.Command{
 	Short: "Display the version of conduktor",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Version: %s\nHash: %s\n", version, hash)
+		fmt.Printf("Version: %s\nHash: %s\n", utils.GetConduktorVersion(), utils.GetConduktorHash())
 	},
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'github.com/conduktor/ctl/cmd.version=$version' -X 'github.com/conduktor/ctl/cmd.hash=$hash'" -o /conduktor . && rm -rf /app
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'github.com/conduktor/ctl/utils.version=$version' -X 'github.com/conduktor/ctl/utils.hash=$hash'" -o /conduktor . && rm -rf /app
 CMD ["/bin/conduktor"]
 
 FROM alpine:3.19

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,0 +1,12 @@
+package utils
+
+var version = "unknown"
+var hash = "unknown"
+
+func GetConduktorVersion() string {
+	return version
+}
+
+func GetConduktorHash() string {
+	return hash
+}


### PR DESCRIPTION
This header is used by Console API to identify the type of client calling the public API.