### PR TITLE
Fix: add prefix X- to custom header

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -19,7 +19,7 @@ type Client struct {
 }
 
 func Make(token string, baseUrl string, debug bool, key, cert string) (*Client, error) {
-	restyClient := resty.New().SetDebug(debug).SetHeader("Authorization", "Bearer "+token).SetHeader("CDK-CLIENT", "CLI/"+utils.GetConduktorVersion())
+	restyClient := resty.New().SetDebug(debug).SetHeader("Authorization", "Bearer "+token).SetHeader("X-CDK-CLIENT", "CLI/"+utils.GetConduktorVersion())
 	if (key == "" && cert != "") || (key != "" && cert == "") {
 		return nil, fmt.Errorf("key and cert must be provided together")
 	} else if key != "" && cert != "" {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -32,7 +32,7 @@ func TestApplyShouldWork(t *testing.T) {
 		"http://baseUrl/public/v1/topic",
 		nil,
 		httpmock.HeaderIs("Authorization", "Bearer "+token).
-			And(httpmock.HeaderIs("CDK-CLIENT", "CLI/unknown")).
+			And(httpmock.HeaderIs("X-CDK-CLIENT", "CLI/unknown")).
 			And(httpmock.BodyContainsBytes(topic.Json)),
 		responder,
 	)
@@ -143,7 +143,7 @@ func TestGetShouldWork(t *testing.T) {
 		"http://baseUrl/public/v1/application",
 		nil,
 		httpmock.HeaderIs("Authorization", "Bearer "+token).
-			And(httpmock.HeaderIs("CDK-CLIENT", "CLI/unknown")),
+			And(httpmock.HeaderIs("X-CDK-CLIENT", "CLI/unknown")),
 		responder,
 	)
 
@@ -265,7 +265,7 @@ func TestDescribeShouldWork(t *testing.T) {
 		"http://baseUrl/public/v1/application/yo",
 		nil,
 		httpmock.HeaderIs("Authorization", "Bearer "+token).
-			And(httpmock.HeaderIs("CDK-CLIENT", "CLI/unknown")),
+			And(httpmock.HeaderIs("X-CDK-CLIENT", "CLI/unknown")),
 		responder,
 	)
 
@@ -326,7 +326,7 @@ func TestDeleteShouldWork(t *testing.T) {
 		"http://baseUrl/public/v1/application/yo",
 		nil,
 		httpmock.HeaderIs("Authorization", "Bearer "+token).
-			And(httpmock.HeaderIs("CDK-CLIENT", "CLI/unknown")),
+			And(httpmock.HeaderIs("X-CDK-CLIENT", "CLI/unknown")),
 		responder,
 	)
 


### PR DESCRIPTION
Not mandatory by [RFC6648](https://www.rfc-editor.org/rfc/rfc6648) but as this header is Conduktor custom and extremely unlikely to become standard it's better to still prefix it with `X-`