### PR TITLE
keep order from api response

### DIFF
--- a/orderedjson/orderedjson.go
+++ b/orderedjson/orderedjson.go
@@ -1,0 +1,65 @@
+package orderedjson
+
+import (
+	"encoding/json"
+
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+	yaml "gopkg.in/yaml.v3"
+)
+
+type OrderedData struct {
+	orderedMap *orderedmap.OrderedMap[string, OrderedData]
+	array      *[]OrderedData
+	fallback   *interface{}
+}
+
+func (orderedData *OrderedData) UnmarshalJSON(data []byte) error {
+	orderedData.orderedMap = orderedmap.New[string, OrderedData]()
+	err := json.Unmarshal(data, &orderedData.orderedMap)
+	if err != nil {
+		orderedData.orderedMap = nil
+		orderedData.array = new([]OrderedData)
+		err = json.Unmarshal(data, orderedData.array)
+	}
+	if err != nil {
+		orderedData.array = nil
+		orderedData.fallback = new(interface{})
+		err = json.Unmarshal(data, &orderedData.fallback)
+	}
+	return err
+}
+
+// TODO: remove once hack in printYaml is not needed anymore
+func (orderedData *OrderedData) GetMapOrNil() *orderedmap.OrderedMap[string, OrderedData] {
+	return orderedData.orderedMap
+}
+
+// TODO: remove once hack in printYaml is not needed anymore
+func (orderedData *OrderedData) GetArrayOrNil() *[]OrderedData {
+	return orderedData.array
+}
+
+func (orderedData OrderedData) MarshalJSON() ([]byte, error) {
+	if orderedData.orderedMap != nil {
+		return json.Marshal(orderedData.orderedMap)
+	} else if orderedData.array != nil {
+		return json.Marshal(orderedData.array)
+	} else if orderedData.fallback != nil {
+		return json.Marshal(orderedData.fallback)
+	} else {
+		return json.Marshal(nil)
+	}
+}
+
+func (orderedData OrderedData) MarshalYAML() (interface{}, error) {
+	if orderedData.orderedMap != nil {
+		return orderedData.orderedMap, nil
+	} else if orderedData.array != nil {
+		return orderedData.array, nil
+	}
+	return orderedData.fallback, nil
+}
+
+func (orderedData *OrderedData) UnmarshalYAML(value *yaml.Node) error {
+	panic("Not supported")
+}

--- a/orderedjson/orderingjson_test.go
+++ b/orderedjson/orderingjson_test.go
@@ -1,0 +1,79 @@
+package orderedjson
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+func TestOrderedRecursiveMap(t *testing.T) {
+	testForJson(t, `{"name":"John","age":30,"city":"New York","children":[{"name":"Alice","age":5},{"name":"Bob","age":7}],"parent":{"name":"Jane","age":60,"city":"New York"}}`)
+	testForJson(t, `"yo"`)
+	testForJson(t, `true`)
+	testForJson(t, `false`)
+	testForJson(t, `42`)
+	testForJson(t, `42.2`)
+	testForJson(t, `[]`)
+	testForJson(t, `{}`)
+	testForJson(t, `{"z":{"x":{"v":{}}},"y":{"u":{"t":"p"}}}`)
+	testForJson(t, `[[[[]]]]`)
+	testForJson(t, `[{"z":42},{"b":{},"y":41,"a":[[{"z":42},{"b":{},"y":41,"a":[[{"z":42},{"b":{},"y":41,"a":[[{"z":42},{"b":{},"y":41,"a":[]}]]}]]}]]}]`)
+}
+
+func testForJson(t *testing.T, originalJSON string) {
+	// Unmarshal the JSON into an OrderedRecursiveMap
+	var omap OrderedData
+	err := json.Unmarshal([]byte(originalJSON), &omap)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %+v", err)
+	}
+
+	fmt.Printf("%v\n", omap)
+	// Marshal the OrderedRecursiveMap back into JSON
+	marshaledJSON, err := json.Marshal(&omap)
+	if err != nil {
+		t.Fatalf("Failed to marshal OrderedRecursiveMap: %v", err)
+	}
+
+	// Check if the original JSON and the marshaled JSON are the same
+	if originalJSON != string(marshaledJSON) {
+		t.Errorf("Original JSON and marshaled JSON do not match. Original: %s, Marshaled: %s", originalJSON, string(marshaledJSON))
+	}
+}
+
+func TestYamlMarshallingKeepOrderTo(t *testing.T) {
+	// Unmarshal the JSON into an OrderedRecursiveMap
+	var omap OrderedData
+	err := json.Unmarshal([]byte(`{"name":"John","age":30,"city":"New York","children":[{"name":"Alice","age":5},{"name":"Bob","age":7}],"parent":{"name":"Jane","age":60,"city":"New York"}}`), &omap)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %+v", err)
+	}
+
+	fmt.Printf("%v\n", omap)
+	// Marshal the OrderedRecursiveMap back into JSON
+	marshaledYaml, err := yaml.Marshal(&omap)
+	if err != nil {
+		t.Fatalf("Failed to marshal OrderedRecursiveMap: %v", err)
+	}
+
+	expected := `name: John
+age: 30
+city: New York
+children:
+    - name: Alice
+      age: 5
+    - name: Bob
+      age: 7
+parent:
+    name: Jane
+    age: 60
+    city: New York
+`
+
+	// Check if the original JSON and the marshaled JSON are the same
+	if expected != string(marshaledYaml) {
+		t.Errorf("Marshalled yaml is not valid. Got:\n##\n%s\n##\n,\nMarshaled:\n##\n%s\n##", string(marshaledYaml), expected)
+	}
+}

--- a/printutils/printYaml.go
+++ b/printutils/printYaml.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"slices"
 
+	"github.com/conduktor/ctl/orderedjson"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -21,6 +23,7 @@ func printKeyYaml(w io.Writer, key string, data interface{}) error {
 	return nil
 }
 
+// TODO: delete once backend properly send resource fields in correct order
 // this print a interface that is expected to a be a resource
 // with the following field "version", "kind", "spec", "metadata"
 // wit the field in a defined order.
@@ -31,21 +34,49 @@ func printResource(w io.Writer, data interface{}) error {
 	if err != nil {
 		return err
 	}
-	asMap, ok := data.(map[string]interface{})
-	if !ok {
-		fmt.Fprint(w, string(yamlBytes))
+	asMap, isMap := data.(map[string]interface{})
+	orderedData, isOrderedData := data.(orderedjson.OrderedData)
+	isOrderedMap := false
+	var asOrderedMap *orderedmap.OrderedMap[string, orderedjson.OrderedData]
+	if isOrderedData {
+		asOrderedMap = orderedData.GetMapOrNil()
+		isOrderedMap = asOrderedMap != nil
+	}
+	if isOrderedMap {
+		printResourceOrderedMapInCorrectOrder(w, *asOrderedMap)
+	} else if isMap {
+		printResourceMapInCorrectOrder(w, asMap)
 	} else {
-		wantedKeys := []string{"apiVersion", "kind", "metadata", "spec"}
-		for _, wantedKey := range wantedKeys {
-			printKeyYaml(w, wantedKey, asMap[wantedKey])
-		}
-		for otherKey, data := range asMap {
-			if !slices.Contains(wantedKeys, otherKey) {
-				printKeyYaml(w, otherKey, data)
-			}
-		}
+		fmt.Fprint(w, string(yamlBytes))
 	}
 	return err
+}
+
+func printResourceMapInCorrectOrder(w io.Writer, dataAsMap map[string]interface{}) {
+	wantedKeys := []string{"apiVersion", "kind", "metadata", "spec"}
+	for _, wantedKey := range wantedKeys {
+		printKeyYaml(w, wantedKey, dataAsMap[wantedKey])
+	}
+	for otherKey, data := range dataAsMap {
+		if !slices.Contains(wantedKeys, otherKey) {
+			printKeyYaml(w, otherKey, data)
+		}
+	}
+}
+
+func printResourceOrderedMapInCorrectOrder(w io.Writer, dataAsMap orderedmap.OrderedMap[string, orderedjson.OrderedData]) {
+	wantedKeys := []string{"apiVersion", "kind", "metadata", "spec"}
+	for _, wantedKey := range wantedKeys {
+		value, ok := dataAsMap.Get(wantedKey)
+		if ok {
+			printKeyYaml(w, wantedKey, value)
+		}
+	}
+	for pair := dataAsMap.Oldest(); pair != nil; pair = pair.Next() {
+		if !slices.Contains(wantedKeys, pair.Key) {
+			printKeyYaml(w, pair.Key, pair.Value)
+		}
+	}
 }
 
 // take a interface that can be a resource or multiple resource
@@ -54,6 +85,19 @@ func PrintResourceLikeYamlFile(w io.Writer, data interface{}) error {
 	switch dataType := data.(type) {
 	case []interface{}:
 		for _, d := range dataType {
+			fmt.Fprintln(w, "---")
+			err := printResource(w, d)
+			if err != nil {
+				return err
+			}
+		}
+	case orderedjson.OrderedData:
+		array := dataType.GetArrayOrNil()
+		if array == nil {
+			return printResource(w, data)
+		}
+
+		for _, d := range *array {
 			fmt.Fprintln(w, "---")
 			err := printResource(w, d)
 			if err != nil {


### PR DESCRIPTION
The issue with go is that when it deserializes from JSON it uses Map which loses order.
To avoid that I build a custom structure using orderedMap that keeps insertion order.
This structure supports JSON marshalling/unmarshalling and yaml marshalling.

But what's funny is that before, we already had a hack to have a fixed order for top-level field:
 - apiVersion
 - kind
 - metadata
 - spec
 
 And unfortunately current release of console-plus does not respect this order.
 So I had to keep old hack and adapt it to the new structure until we fix that on the backend
