### PR TITLE
Support delete -f

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -259,6 +259,30 @@ func (client *Client) Delete(kind *schema.Kind, parentPathValue []string, name s
 	return err
 }
 
+func (client *Client) DeleteResource(resource *resource.Resource) error {
+	client.setApiKeyFromEnvIfNeeded()
+	kinds := client.GetKinds()
+	kind, ok := kinds[resource.Kind]
+	if !ok {
+		return fmt.Errorf("kind %s not found", resource.Kind)
+	}
+	deletePath, err := kind.DeletePath(resource)
+	if err != nil {
+		return err
+	}
+	url := client.baseUrl + deletePath
+	resp, err := client.client.R().Delete(url)
+	if err != nil {
+		return err
+	} else if resp.IsError() {
+		return fmt.Errorf(extractApiError(resp))
+	} else {
+		fmt.Printf("%s/%s deleted\n", kind.GetName(), resource.Name)
+	}
+
+	return err
+}
+
 func (client *Client) GetOpenApi() ([]byte, error) {
 	url := client.baseUrl + "/public/docs/docs.yaml"
 	resp, err := client.client.R().Get(url)

--- a/cmd/load_resource_utils.go
+++ b/cmd/load_resource_utils.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/conduktor/ctl/resource"
+)
+
+func loadResourceFromFileFlag(filePath []string) []resource.Resource {
+	var resources = make([]resource.Resource, 0)
+	for _, path := range filePath {
+		r, err := resourceForPath(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			os.Exit(1)
+		}
+		resources = append(resources, r...)
+	}
+	return resources
+}

--- a/docker/initializer.json
+++ b/docker/initializer.json
@@ -73,6 +73,42 @@
   },
   {
     "httpRequest": {
+      "method": "Delete",
+      "path": "/public/kafka/v2/cluster/my-cluster/topic/abcd.topic",
+      "headers": {
+        "Authorization": "Bearer yo"
+      }
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": "{}",
+      "headers": {
+        "Content-Type": [
+          "application/json"
+        ]
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "method": "Delete",
+      "path": "/public/kafka/v2/cluster/my-cluster/topic/abcd.myTopicWrong",
+      "headers": {
+        "Authorization": "Bearer yo"
+      }
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": "{}",
+      "headers": {
+        "Content-Type": [
+          "application/json"
+        ]
+      }
+    }
+  },
+  {
+    "httpRequest": {
       "method": "Post",
       "path": "/api/login",
       "body": {

--- a/schema/kind.go
+++ b/schema/kind.go
@@ -138,3 +138,12 @@ func (kind *Kind) ApplyPath(resource *resource.Resource) (string, error) {
 	}
 	return kind.ListPath(parentPathValues), nil
 }
+
+func (kind *Kind) DeletePath(resource *resource.Resource) (string, error) {
+	applyPath, err := kind.ApplyPath(resource)
+	if err != nil {
+		return "", err
+	}
+
+	return applyPath + "/" + resource.Name, nil
+}

--- a/schema/sort.go
+++ b/schema/sort.go
@@ -39,9 +39,21 @@ func resourcePriority(catalog KindCatalog, resource resource.Resource, debug, fa
 	}
 }
 
-func SortResources(catalog KindCatalog, resources []resource.Resource, debug bool) {
+func SortResourcesForApply(catalog KindCatalog, resources []resource.Resource, debug bool) {
+	sortResources(catalog, resources, debug, false)
+}
+
+func SortResourcesForDelete(catalog KindCatalog, resources []resource.Resource, debug bool) {
+	sortResources(catalog, resources, debug, true)
+}
+
+func sortResources(catalog KindCatalog, resources []resource.Resource, debug bool, reverse bool) {
 	sort.SliceStable(resources, func(i, j int) bool {
-		return resourcePriority(catalog, resources[i], debug, true) < resourcePriority(catalog, resources[j], debug, true)
+		if reverse {
+			return resourcePriority(catalog, resources[i], debug, true) > resourcePriority(catalog, resources[j], debug, true)
+		} else {
+			return resourcePriority(catalog, resources[i], debug, true) < resourcePriority(catalog, resources[j], debug, true)
+		}
 	})
 
 }

--- a/schema/sort_test.go
+++ b/schema/sort_test.go
@@ -35,7 +35,7 @@ func TestSortResources(t *testing.T) {
 		{Kind: "kind2", Version: "v1"},
 	}
 
-	SortResources(catalog, resources, false)
+	SortResourcesForApply(catalog, resources, false)
 
 	expected := []resource.Resource{
 		{Kind: "kind1", Version: "v1"},

--- a/test_final_exec.sh
+++ b/test_final_exec.sh
@@ -16,6 +16,9 @@ main() {
 	docker compose -f docker/docker-compose.yml up -d mock
 	sleep 1
 	docker compose -f docker/docker-compose.yml run conduktor apply -f /test_resource.yml
+	docker compose -f docker/docker-compose.yml run conduktor apply -f /
+	docker compose -f docker/docker-compose.yml run conduktor delete -f /test_resource.yml
+	docker compose -f docker/docker-compose.yml run conduktor apply -f /
 	docker compose -f docker/docker-compose.yml run conduktor get Topic yolo --cluster=my-cluster
 	docker compose -f docker/docker-compose.yml run conduktor delete Topic yolo -v --cluster=my-cluster
 	docker compose -f docker/docker-compose.yml run -e CDK_USER=admin -e CDK_PASSWORD=secret conduktor login


### PR DESCRIPTION
This PR allows using `delete` command with the  `-file` argument in a similar way to the `apply` command.
`-f` accepts either a file path or a folder (in this case it would look inside it recursively for file having either `.yml` or `.yaml` extension.
A user can also provide multiple file by providing multiple `-f` flags.