### PR TITLE
Fix missing key retrieval from env

### DIFF
--- a/client/console_client.go
+++ b/client/console_client.go
@@ -107,6 +107,7 @@ func MakeFromEnv() (*Client, error) {
 	apiParameter := ApiParameter{
 		BaseUrl:     os.Getenv("CDK_BASE_URL"),
 		Debug:       utils.CdkDebug(),
+		Key:         os.Getenv("CDK_KEY"),
 		Cert:        os.Getenv("CDK_CERT"),
 		Cacert:      os.Getenv("CDK_CACERT"),
 		ApiKey:      os.Getenv("CDK_API_KEY"),


### PR DESCRIPTION
It was impossible to connect ctl to our staging env because the key was not passed to the ApiParamter:

```
Cannot create client: Cannot create client: CDK_KEY and CDK_CERT must be provided together
```