### PR TITLE
Support basic auth for API gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ CDK_GATEWAY_USER=admin
 CDK_GATEWAY_PASSWORD=conduktor
 ````
 
+### Configuring the CLI for authenticating through an API Gateway
+Console has the ability to delegate the authentication to an API Gateway.
+To provide the credentials to the API Gateway you can either use a bearer token: 
+````yaml
+CDK_BASE_URL=http://localhost:8080
+CDK_AUTH_MODE=external
+CDK_API_KEY=<token>
+````
+
+or basic auth:
+````yaml
+CDK_BASE_URL=http://localhost:8080
+CDK_AUTH_MODE=external
+CDK_USER=<client_id>
+CDK_PASSWORD=<client_secret>
+````
+
+
 ### Commands Usage
 ````
 You need to define the CDK_API_KEY and CDK_BASE_URL environment variables to use this tool.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -77,15 +77,16 @@ func TestApplyShouldWork(t *testing.T) {
 	}
 }
 
-func TestApplyShouldWorkWithExternalUser(t *testing.T) {
+func TestApplyShouldWorkWithExternalAuthMode(t *testing.T) {
 	defer httpmock.Reset()
 	baseUrl := "http://baseUrl"
-	externalUser := "user"
-	externalPassword := "password"
+	user := "user"
+	password := "password"
 	client, err := Make(ApiParameter{
-		BaseUrl:          baseUrl,
-		ExternalUser:     externalUser,
-		ExternalPassword: externalPassword,
+		BaseUrl:     baseUrl,
+		CdkUser:     user,
+		CdkPassword: password,
+		AuthMode:    "ExTerNaL",
 	})
 	if err != nil {
 		panic(err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -42,7 +42,7 @@ func TestApplyShouldWork(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	client.setApiKeyFromEnvIfNeeded()
+	client.setAuthMethodFromEnvIfNeeded()
 	httpmock.ActivateNonDefault(
 		client.client.GetClient(),
 	)
@@ -63,6 +63,54 @@ func TestApplyShouldWork(t *testing.T) {
 		"http://baseUrl/api/public/kafka/v2/cluster/local/topic",
 		nil,
 		httpmock.HeaderIs("Authorization", "Bearer "+apiKey).
+			And(httpmock.HeaderIs("X-CDK-CLIENT", "CLI/unknown")).
+			And(httpmock.BodyContainsBytes(topic.Json)),
+		responder,
+	)
+
+	body, err := client.Apply(&topic, false)
+	if err != nil {
+		t.Error(err)
+	}
+	if body != "NotChanged" {
+		t.Errorf("Bad result expected NotChanged got: %s", body)
+	}
+}
+
+func TestApplyShouldWorkWithExternalUser(t *testing.T) {
+	defer httpmock.Reset()
+	baseUrl := "http://baseUrl"
+	externalUser := "user"
+	externalPassword := "password"
+	client, err := Make(ApiParameter{
+		BaseUrl:          baseUrl,
+		ExternalUser:     externalUser,
+		ExternalPassword: externalPassword,
+	})
+	if err != nil {
+		panic(err)
+	}
+	client.setAuthMethodFromEnvIfNeeded()
+	httpmock.ActivateNonDefault(
+		client.client.GetClient(),
+	)
+	responder := httpmock.NewStringResponder(200, `{"upsertResult": "NotChanged"}`)
+
+	topic := resource.Resource{
+		Json:    []byte(`{"yolo": "data"}`),
+		Kind:    "Topic",
+		Name:    "toto",
+		Version: "v2",
+		Metadata: map[string]interface{}{
+			"cluster": "local",
+		},
+	}
+
+	httpmock.RegisterMatcherResponderWithQuery(
+		"PUT",
+		"http://baseUrl/api/public/kafka/v2/cluster/local/topic",
+		nil,
+		httpmock.HeaderIs("Authorization", "Basic dXNlcjpwYXNzd29yZA==").
 			And(httpmock.HeaderIs("X-CDK-CLIENT", "CLI/unknown")).
 			And(httpmock.BodyContainsBytes(topic.Json)),
 		responder,

--- a/client/console_client.go
+++ b/client/console_client.go
@@ -88,7 +88,7 @@ func Make(apiParameter ApiParameter) (*Client, error) {
 	}
 
 	if (apiParameter.ExternalUser != "" && apiParameter.ExternalPassword == "") || (apiParameter.ExternalUser == "" && apiParameter.ExternalPassword != "") {
-		return nil, fmt.Errorf("CDK_EXTERNAL_USER and CDK_EXTERNAL_PASSWORD must be provided together")
+		return nil, fmt.Errorf("CDK_REMOTE_AUTH_USER and CDK_REMOTE_AUTH_PASSWORD must be provided together")
 	}
 
 	if apiParameter.CdkUser != "" && apiParameter.ApiKey != "" {
@@ -96,11 +96,11 @@ func Make(apiParameter ApiParameter) (*Client, error) {
 	}
 
 	if apiParameter.ExternalUser != "" && apiParameter.ApiKey != "" {
-		return nil, fmt.Errorf("Can't set both CDK_EXTERNAL_USER and CDK_API_KEY")
+		return nil, fmt.Errorf("Can't set both CDK_REMOTE_AUTH_USER and CDK_API_KEY")
 	}
 
 	if apiParameter.CdkUser != "" && apiParameter.ExternalUser != "" {
-		return nil, fmt.Errorf("Can't set both CDK_USER and CDK_EXTERNAL_USER")
+		return nil, fmt.Errorf("Can't set both CDK_USER and CDK_REMOTE_AUTH_USER")
 	}
 
 	if apiParameter.Cacert != "" {
@@ -161,8 +161,8 @@ func MakeFromEnv() (*Client, error) {
 		ApiKey:           os.Getenv("CDK_API_KEY"),
 		CdkUser:          os.Getenv("CDK_USER"),
 		CdkPassword:      os.Getenv("CDK_PASSWORD"),
-		ExternalUser:     os.Getenv("CDK_EXTERNAL_USER"),
-		ExternalPassword: os.Getenv("CDK_EXTERNAL_PASSWORD"),
+		ExternalUser:     os.Getenv("CDK_REMOTE_AUTH_USER"),
+		ExternalPassword: os.Getenv("CDK_REMOTE_AUTH_PASSWORD"),
 		Insecure:         strings.ToLower(os.Getenv("CDK_INSECURE")) == "true",
 	}
 
@@ -184,21 +184,21 @@ func (c *Client) IgnoreUntrustedCertificate() {
 func (c *Client) setAuthMethodFromEnvIfNeeded() {
 	if c.authMethod == nil {
 		apiKey := os.Getenv("CDK_API_KEY")
-		externalUser := os.Getenv("CDK_EXTERNAL_USER")
-		externalPassword := os.Getenv("CDK_EXTERNAL_PASSWORD")
+		externalUser := os.Getenv("CDK_REMOTE_AUTH_USER")
+		externalPassword := os.Getenv("CDK_REMOTE_AUTH_PASSWORD")
 
 		if apiKey == "" && externalUser == "" {
-			fmt.Fprintln(os.Stderr, "Please set CDK_API_KEY or CDK_EXTERNAL_USER/CDK_EXTERNAL_PASSWORD")
+			fmt.Fprintln(os.Stderr, "Please set CDK_API_KEY or CDK_REMOTE_AUTH_USER/CDK_REMOTE_AUTH_PASSWORD")
 			os.Exit(1)
 		}
 
 		if apiKey != "" && externalUser != "" {
-			fmt.Fprintln(os.Stderr, "Can't set both CDK_API_KEY and CDK_EXTERNAL_USER")
+			fmt.Fprintln(os.Stderr, "Can't set both CDK_API_KEY and CDK_REMOTE_AUTH_USER")
 			os.Exit(1)
 		}
 
 		if externalUser != "" && externalPassword == "" {
-			fmt.Fprintln(os.Stderr, "Please set CDK_EXTERNAL_PASSWORD when using CDK_EXTERNAL_USER")
+			fmt.Fprintln(os.Stderr, "Please set CDK_REMOTE_AUTH_PASSWORD when using CDK_REMOTE_AUTH_USER")
 			os.Exit(1)
 		}
 
@@ -214,7 +214,7 @@ func (c *Client) setAuthMethodFromEnvIfNeeded() {
 
 func (c *Client) setAuthMethodInRestClient() {
 	if c.authMethod == nil {
-		fmt.Fprintln(os.Stderr, "No authentication method defined. Please set CDK_API_KEY or CDK_USER/CDK_PASSWORD or CDK_EXTERNAL_USER/CDK_EXTERNAL_PASSWORD")
+		fmt.Fprintln(os.Stderr, "No authentication method defined. Please set CDK_API_KEY or CDK_USER/CDK_PASSWORD or CDK_REMOTE_AUTH_USER/CDK_REMOTE_AUTH_PASSWORD")
 		os.Exit(1)
 	}
 	c.client = c.client.SetHeader("Authorization", c.authMethod.AuthorizationHeader())


### PR DESCRIPTION
New environment variables to support Basic auth. This is needed when an API gateway sits between the CLI and Console. 
It allows to pass client id and secret to the gateway which in turn will send a JWT token to Console.

Tested with Kong openid-connect plugin + Keycloak