### PR TITLE
Add a tools to quickly get an url on console settings credential

### DIFF
--- a/client/console_client_test.go
+++ b/client/console_client_test.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOnlyPathWithSlashApi_UrlWithApi(t *testing.T) {
+	inputUrl := "https://example.com/api/resource"
+	expected := "/resource"
+	result := getOnlyPathWithSlashApi(inputUrl)
+	assert.Equal(t, expected, result)
+}
+
+func TestGetOnlyPathWithSlashApi_UrlWithoutApi(t *testing.T) {
+	inputUrl := "https://example.com/resource"
+	expected := "/resource"
+	result := getOnlyPathWithSlashApi(inputUrl)
+	assert.Equal(t, expected, result)
+}
+
+func TestGetOnlyPathWithSlashApi_PathWithoutApi(t *testing.T) {
+	inputUrl := "https://example.com/resource"
+	expected := "/resource"
+	result := getOnlyPathWithSlashApi(inputUrl)
+	assert.Equal(t, expected, result)
+}
+
+func TestGetOnlyPathWithSlashApi_PathWithApi(t *testing.T) {
+	inputUrl := "api/resource"
+	expected := "/resource"
+	result := getOnlyPathWithSlashApi(inputUrl)
+	assert.Equal(t, expected, result)
+}

--- a/cmd/consoleMkKind.go
+++ b/cmd/consoleMkKind.go
@@ -16,7 +16,7 @@ func initConsoleMkKind() {
 		Long:    ``,
 		Aliases: []string{"mkKind", "makeConsoleKind"},
 		Args:    cobra.RangeArgs(0, 1),
-		Hidden:  !utils.CdkDebug(),
+		Hidden:  !utils.CdkDevMode(),
 		Run: func(cmd *cobra.Command, args []string) {
 			runMkKind(cmd, args, *prettyPrint, *nonStrict, func() ([]byte, error) { return consoleApiClient().GetOpenApi() }, func(schema *schema.Schema, strict bool) (schema.KindCatalog, error) {
 				return schema.GetConsoleKinds(strict)

--- a/cmd/console_url_get.go
+++ b/cmd/console_url_get.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// consoleUrlGetCmd represents the apply command
+var consoleUrlGetCmd = &cobra.Command{
+	Use:   "consoleUrlGet",
+	Short: "Perform a get on the given url/path with correct authentication header",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		result, err := consoleApiClient().UrlGet(args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not perform get: %s\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(result)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(consoleUrlGetCmd)
+}

--- a/cmd/console_url_get.go
+++ b/cmd/console_url_get.go
@@ -10,8 +10,10 @@ import (
 
 // consoleUrlGetCmd represents the apply command
 var consoleUrlGetCmd = &cobra.Command{
-	Use:    "consoleUrlGet",
-	Short:  "Perform a get on the given url/path with correct authentication header",
+	Use:   "consoleUrlGet",
+	Short: "Perform a get on the given url/path with correct authentication header",
+	Long: `Perform a get on the given url/path with correct authentication header.
+If a full url is given the host part will be ignored and replace by $CDK_BASE_URL. If /api is missing it will be added automatically`,
 	Args:   cobra.ExactArgs(1),
 	Hidden: !utils.CdkDevMode(),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/console_url_get.go
+++ b/cmd/console_url_get.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/conduktor/ctl/utils"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -9,9 +10,10 @@ import (
 
 // consoleUrlGetCmd represents the apply command
 var consoleUrlGetCmd = &cobra.Command{
-	Use:   "consoleUrlGet",
-	Short: "Perform a get on the given url/path with correct authentication header",
-	Args:  cobra.ExactArgs(1),
+	Use:    "consoleUrlGet",
+	Short:  "Perform a get on the given url/path with correct authentication header",
+	Args:   cobra.ExactArgs(1),
+	Hidden: !utils.CdkDevMode(),
 	Run: func(cmd *cobra.Command, args []string) {
 		result, err := consoleApiClient().UrlGet(args[0])
 		if err != nil {

--- a/cmd/gatewayMkKind.go
+++ b/cmd/gatewayMkKind.go
@@ -16,7 +16,7 @@ func initGatewayMkKind() {
 		Long:    ``,
 		Aliases: []string{"gatewayMkKind", "gwMkKind"},
 		Args:    cobra.RangeArgs(0, 1),
-		Hidden:  !utils.CdkDebug(),
+		Hidden:  !utils.CdkDevMode(),
 		Run: func(cmd *cobra.Command, args []string) {
 			runMkKind(cmd, args, *prettyPrint, *nonStrict, func() ([]byte, error) { return gatewayApiClient().GetOpenApi() }, func(schema *schema.Schema, strict bool) (schema.KindCatalog, error) {
 				return schema.GetGatewayKinds(strict)

--- a/cmd/printKind.go
+++ b/cmd/printKind.go
@@ -18,7 +18,7 @@ func initPrintKind(kinds schema.KindCatalog) {
 		Short:  "Print kind catalog used",
 		Long:   ``,
 		Args:   cobra.NoArgs,
-		Hidden: !utils.CdkDebug(),
+		Hidden: !utils.CdkDevMode(),
 		Run: func(cmd *cobra.Command, args []string) {
 			var payload []byte
 			var err error

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,9 @@ require (
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/pb33f/libopenapi v0.15.14
 	github.com/spf13/cobra v1.8.0
-	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
+	github.com/stretchr/testify v1.8.4
+	github.com/thediveo/enumflag/v2 v2.0.5
+	github.com/wk8/go-ordered-map/v2 v2.1.8
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -20,10 +22,10 @@ require (
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/thediveo/enumflag/v2 v2.0.5 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,9 +19,13 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
+github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-resty/resty/v2 v2.11.0 h1:i7jMfNOJYMp69lq7qozJP+bjgzfAzeOhuGlyDrqxT/8=
 github.com/go-resty/resty/v2 v2.11.0/go.mod h1:iiP/OpA0CkcL3IGt1O0+/SIItFUbkkyw5BGXiVdTu+A=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -35,6 +39,9 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -61,13 +68,15 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
+github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
+github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.28.1 h1:MijcGUbfYuznzK/5R4CPNoUP/9Xvuo20sXfEm6XxoTA=
+github.com/onsi/gomega v1.28.1/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
 github.com/pb33f/libopenapi v0.15.14 h1:A0fn45jbthDyFGXfu5bYIZVsWyPI6hJYm3wG143MT8o=
 github.com/pb33f/libopenapi v0.15.14/go.mod h1:PEXNwvtT4KNdjrwudp5OYnD1ryqK6uJ68aMNyWvoMuc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -75,6 +84,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -86,6 +97,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/thediveo/enumflag/v2 v2.0.5 h1:VJjvlAqUb6m6mxOrB/0tfBJI0Kvi9wJ8ulh38xK87i8=
 github.com/thediveo/enumflag/v2 v2.0.5/go.mod h1:0NcG67nYgwwFsAvoQCmezG0J0KaIxZ0f7skg9eLq1DA=
+github.com/thediveo/success v1.0.1 h1:NVwUOwKUwaN8szjkJ+vsiM2L3sNBFscldoDJ2g2tAPg=
+github.com/thediveo/success v1.0.1/go.mod h1:AZ8oUArgbIsCuDEWrzWNQHdKnPbDOLQsWOFj9ynwLt0=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
@@ -165,6 +178,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
+golang.org/x/tools v0.18.0 h1:k8NLag8AGHnn+PHbl7g43CtqZAwG60vZkLqgyZgIHgQ=
+golang.org/x/tools v0.18.0/go.mod h1:GL7B4CwcLLeo59yx/9UWWuNOW1n3VZ4f5axWfML7Lcg=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/utils/cdk_debug.go
+++ b/utils/cdk_debug.go
@@ -8,3 +8,7 @@ import (
 func CdkDebug() bool {
 	return strings.ToLower(os.Getenv("CDK_DEBUG")) == "true"
 }
+
+func CdkDevMode() bool {
+	return strings.ToLower(os.Getenv("CDK_DEV_MODE")) == "true"
+}


### PR DESCRIPTION
It will make our job easier:

The command except normally a path to append to $CDK_BASE_URL/api.
But if the path start with /api it's truncated. Also if the path is a full URL. The hostname:port part of the URL is ignored. This is done to copy/paste fastly from the openapi documentation.

For example if CDK_BASE_URL=http://z.com:
 - conduktor consoleUrlGet partner-zone-state/gw will perform a get on http://z.com/api/partner-zone-state/gw
 - conduktor consoleUrlGet /api/partner-zone-state/gw will perform a get on http://z.com/api/partner-zone-state/gw
  - conduktor consoleUrlGet http://localhost:8080/api/partner-zone-state/gw will perform a get on http://z.com/api/partner-zone-state/gw