### PR TITLE
fix: buildAlias duplication fixed

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -69,7 +69,13 @@ func removeTrailingSIfAny(name string) string {
 }
 
 func buildAlias(name string) []string {
-	return []string{strings.ToLower(name), removeTrailingSIfAny(strings.ToLower(name)), removeTrailingSIfAny(name)}
+	aliases := []string{strings.ToLower(name)}
+	// This doesn't seem to be needed since none of the kinds ends with an S
+	// However I'm leaving it here as a conditional so it won't affect the usage
+	if strings.HasSuffix(name, "s") {
+		aliases = append(aliases, removeTrailingSIfAny(name), removeTrailingSIfAny(strings.ToLower(name)))
+	}
+	return aliases
 }
 
 func printResource(result interface{}, format OutputFormat) error {


### PR DESCRIPTION
Fixing aliases duplicates by making conditional usage of the `removeTrailingSIfAny()` function