### PR TITLE
Fix verbose mode in single client configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ go.work
 
 # User-specific stuff
 .idea
+.envrc
 
 # AWS User-specific
 .idea/**/aws.xml

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,8 +40,14 @@ Additionally, you can configure client TLS authentication by providing your cert
 For server TLS authentication, you can ignore the certificate by setting CDK_INSECURE=true, or provide a certificate authority using CDK_CACERT.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if *debug {
-			consoleApiClient().ActivateDebug()
-			gatewayApiClient().ActivateDebug()
+			// ActivateDebug() will enable debug mode for the resty client.
+			// Doesn't need to be set if the client was not initialised correctly.
+			if apiClientError == nil {
+				consoleApiClient().ActivateDebug()
+			}
+			if gatewayApiClientError == nil {
+				gatewayApiClient().ActivateDebug()
+			}
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Verbose mode `-v` enables debug mode on the `resty` client which handles the connection.

This doesn't need to happen if the client wasn't initialised, e.g. when using `ctl` in single client mode.