### PR TITLE
Added Cause field to ApiError made it the default for its String function

### DIFF
--- a/client/api_error.go
+++ b/client/api_error.go
@@ -3,12 +3,15 @@ package client
 type ApiError struct {
 	Title string
 	Msg   string
+	Cause string
 }
 
 func (e *ApiError) String() string {
-	if e.Msg == "" {
-		return e.Title
-	} else {
+	if e.Cause != "" {
+		return e.Cause
+	} else if e.Msg != "" {
 		return e.Msg
+	} else {
+		return e.Title
 	}
 }


### PR DESCRIPTION
We are changing this behaviour due to the fact at present the CLI gives vague error messages that told you the general issue, but not the specific details
![image](https://github.com/user-attachments/assets/1ba62458-9491-4c0a-92db-44f01ce49772)

After changing the default ApiError to return the Cause instead we now not only get the same error message - but also the reason why it failed
![image](https://github.com/user-attachments/assets/443ae216-9aa5-4c84-94c6-bb4a2aed552b)
 

