### PR TITLE
feat: show diff when applying supported resources like ServiceAccount

### DIFF
--- a/client/console_client.go
+++ b/client/console_client.go
@@ -167,12 +167,12 @@ type UpsertResponse struct {
 	UpsertResult string
 }
 
-func (c *Client) IgnoreUntrustedCertificate() {
-	c.client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+func (client *Client) IgnoreUntrustedCertificate() {
+	client.client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 }
 
-func (c *Client) setAuthMethodFromEnvIfNeeded() {
-	if c.authMethod == nil {
+func (client *Client) setAuthMethodFromEnvIfNeeded() {
+	if client.authMethod == nil {
 		authMode := strings.ToLower(os.Getenv("CDK_AUTH_MODE"))
 		apiKey := os.Getenv("CDK_API_KEY")
 
@@ -196,9 +196,9 @@ func (c *Client) setAuthMethodFromEnvIfNeeded() {
 			}
 
 			if apiKey != "" {
-				c.authMethod = BearerToken{apiKey}
+				client.authMethod = BearerToken{apiKey}
 			} else {
-				c.authMethod = BasicAuth{user, password}
+				client.authMethod = BasicAuth{user, password}
 			}
 		} else if authMode == "" || authMode == "conduktor" {
 			if apiKey == "" {
@@ -206,27 +206,27 @@ func (c *Client) setAuthMethodFromEnvIfNeeded() {
 				os.Exit(1)
 			}
 
-			c.authMethod = BearerToken{apiKey}
+			client.authMethod = BearerToken{apiKey}
 		} else {
 			fmt.Fprintf(os.Stderr, "CDK_AUTH_MODE was: \"%s\". Accepted values are \"conduktor\" or \"external\"\n.", authMode)
 			os.Exit(1)
 		}
 
-		c.setAuthMethodInRestClient()
+		client.setAuthMethodInRestClient()
 	}
 }
 
-func (c *Client) setAuthMethodInRestClient() {
-	if c.authMethod == nil {
+func (client *Client) setAuthMethodInRestClient() {
+	if client.authMethod == nil {
 		fmt.Fprintln(os.Stderr, "No authentication method defined. Please set CDK_API_KEY or CDK_USER/CDK_PASSWORD")
 		os.Exit(1)
 	}
-	c.client = c.client.SetHeader("Authorization", c.authMethod.AuthorizationHeader())
+	client.client = client.client.SetHeader("Authorization", client.authMethod.AuthorizationHeader())
 }
 
-func (c *Client) SetApiKey(apiKey string) {
-	c.authMethod = BearerToken{apiKey}
-	c.setAuthMethodInRestClient()
+func (client *Client) SetApiKey(apiKey string) {
+	client.authMethod = BearerToken{apiKey}
+	client.setAuthMethodInRestClient()
 }
 
 func extractApiError(resp *resty.Response) string {
@@ -538,6 +538,6 @@ func (client *Client) GetKinds() schema.KindCatalog {
 	return client.schemaCatalog.Kind
 }
 
-func (c *Client) GetCatalog() *schema.Catalog {
-	return c.schemaCatalog
+func (client *Client) GetCatalog() *schema.Catalog {
+	return client.schemaCatalog
 }

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -28,19 +28,19 @@ func runApply(kinds schema.KindCatalog, filePath []string, strict bool) {
 	resources := loadResourceFromFileFlag(filePath, strict)
 	schema.SortResourcesForApply(kinds, resources, *debug)
 	allSuccess := true
-	for _, resource := range resources {
+	for _, res := range resources {
 		var upsertResult string
 		var err error
-		if isGatewayResource(resource, kinds) {
-			upsertResult, err = gatewayApiClient().Apply(&resource, *dryRun)
+		if isGatewayResource(res, kinds) {
+			upsertResult, err = gatewayApiClient().Apply(&res, *dryRun)
 		} else {
-			upsertResult, err = consoleApiClient().Apply(&resource, *dryRun)
+			upsertResult, err = consoleApiClient().Apply(&res, *dryRun)
 		}
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Could not apply resource %s/%s: %s\n", resource.Kind, resource.Name, err)
+			fmt.Fprintf(os.Stderr, "Could not apply resource %s/%s: %s\n", res.Kind, res.Name, err)
 			allSuccess = false
 		} else {
-			fmt.Printf("%s/%s: %s\n", resource.Kind, resource.Name, upsertResult)
+			fmt.Printf("%s/%s: %s\n", res.Kind, res.Name, upsertResult)
 		}
 	}
 	if !allSuccess {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-resty/resty/v2 v2.11.0
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/pb33f/libopenapi v0.15.14
+	github.com/sergi/go-diff v1.1.0
 	github.com/spf13/cobra v1.8.0
 	github.com/thediveo/enumflag/v2 v2.0.5
 	github.com/wk8/go-ordered-map/v2 v2.1.8

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -239,3 +239,55 @@ func (r *Resource) PrintPreservingOriginalFieldOrder() error {
 	}
 	return printutils.PrintResourceLikeYamlFile(os.Stdout, finalData)
 }
+
+type ServiceAccount struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Cluster string `yaml:"cluster"`
+		Name    string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Authorization struct {
+			Acls []struct {
+				Type        string   `yaml:"type"`
+				Name        string   `yaml:"name"`
+				PatternType string   `yaml:"patternType"`
+				Operations  []string `yaml:"operations"`
+				Host        string   `yaml:"host"`
+				Permission  string   `yaml:"permission"`
+			} `yaml:"acls"`
+			Type string `yaml:"type"`
+		} `yaml:"authorization"`
+	} `yaml:"spec"`
+}
+
+// ConvertToServiceAccount converts a Resource to a ServiceAccount.
+func (r *Resource) ConvertToServiceAccount() (ServiceAccount, error) {
+
+	if r.Kind != "ServiceAccount" {
+		return ServiceAccount{}, fmt.Errorf("only resources of type ServiceAccount can be converted into a ServiceAccount object")
+	}
+
+	sa := ServiceAccount{
+		APIVersion: r.Version,
+		Kind:       r.Kind,
+	}
+	// Set Metadata fields
+	if cluster, ok := r.Metadata["cluster"].(string); ok {
+		sa.Metadata.Cluster = cluster
+	}
+	sa.Metadata.Name = r.Name
+
+	// Marshal and unmarshal the Spec map into the ServiceAccount's Spec
+	specBytes, err := json.Marshal(r.Spec)
+	if err != nil {
+		return ServiceAccount{}, err
+	}
+	err = json.Unmarshal(specBytes, &sa.Spec)
+	if err != nil {
+		return ServiceAccount{}, err
+	}
+
+	return sa, nil
+}

--- a/utils/diff.go
+++ b/utils/diff.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/conduktor/ctl/resource"
+	"github.com/sergi/go-diff/diffmatchpatch"
+	"gopkg.in/yaml.v3"
+	"slices"
+	"sort"
+)
+
+// List of resource kinds that are supported for diffing
+var supportedTypes = []string{
+	"ServiceAccount",
+}
+
+// DiffIsSupported checks if diffing is supported for the given resource type.
+func DiffIsSupported(res *resource.Resource) bool {
+	if slices.Contains(supportedTypes, res.Kind) {
+		return true
+	} else {
+		return false
+	}
+}
+
+// PrintDiff dispatches the diff operation for supported resource types
+// and prints the resulting diff to stdout.
+func PrintDiff(currentResource *resource.Resource, modifiedResource *resource.Resource) error {
+	var txt string
+	var err error
+
+	switch currentResource.Kind {
+	case "ServiceAccount":
+		txt, err = DiffServiceAccount(currentResource, modifiedResource)
+	default:
+		// Unsupported resource kind; nothing to diff
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", txt)
+	return nil
+}
+
+// DiffServiceAccount compares two ServiceAccount objects and returns a unified diff in git-like format.
+func DiffServiceAccount(curSa, newSa *resource.Resource) (string, error) {
+
+	// Convert generic resource representations to ServiceAccount-specific structs
+	a, err := curSa.ConvertToServiceAccount()
+	if err != nil {
+		return "", err
+	}
+	b, err := newSa.ConvertToServiceAccount()
+	if err != nil {
+		return "", err
+	}
+
+	// Sort ACL slices by Name for consistent ordering
+	sort.Slice(a.Spec.Authorization.Acls, func(i, j int) bool {
+		return a.Spec.Authorization.Acls[i].Name < a.Spec.Authorization.Acls[j].Name
+	})
+	sort.Slice(b.Spec.Authorization.Acls, func(i, j int) bool {
+		return b.Spec.Authorization.Acls[i].Name < b.Spec.Authorization.Acls[j].Name
+	})
+
+	// Marshal both structs back to YAML
+	yamlA, err := yaml.Marshal(a)
+	if err != nil {
+		return "", err
+	}
+	yamlB, err := yaml.Marshal(b)
+	if err != nil {
+		return "", err
+	}
+
+	// Create a new diff instance
+	dmp := diffmatchpatch.New()
+
+	// Generate unified diff
+	diffs := dmp.DiffMain(string(yamlA), string(yamlB), false)
+
+	// Format the diff nicely
+	diffText := dmp.DiffPrettyText(diffs)
+	return diffText, nil
+}


### PR DESCRIPTION
This PR introduces the ability to display a unified, human-readable diff when applying certain resources—starting with `ServiceAccount`—to help users understand what changes are being made.

**What's New**
- Diff Support for ServiceAccount Resources:
  - Added `DiffIsSupported()` and `PrintDiff()` functions to the utils package.
  - Implemented `DiffServiceAccount()` to compare the current and modified versions using YAML serialization and `go-diff`.

- `runApply` Enhancements:
  - Before applying a resource, if it supports diffing, the current version is fetched via `GetFromResource()` and the diff is printed.

- New Struct Conversion Logic:
  - Introduced `ConvertToServiceAccount()` to safely convert a generic `Resource` into a typed `ServiceAccount` struct.

**Dependencies**
Added: `github.com/sergi/go-diff v1.1.0` for generating readable diffs.

**How It Works**
For supported resources:
1. Fetch the current version from the API.
2. Marshal both current and updated versions to YAML.
3. Use diffmatchpatch to generate a semantic diff.
4. Print the result before applying the changes.

**Notes**
Only ServiceAccount is supported for now. Additional resource types can be added by extending supportedTypes and implementing corresponding diff logic.

This feature is particularly useful during dry runs and debugging configuration changes.