### PR TITLE
CUS 629 cannot delete alert with cli if you use metadata group

### DIFF
--- a/client/console_client.go
+++ b/client/console_client.go
@@ -390,16 +390,20 @@ func (client *Client) Delete(kind *schema.Kind, parentPathValue []string, parent
 func (client *Client) DeleteResource(resource *resource.Resource) error {
 	client.setAuthMethodFromEnvIfNeeded()
 	kinds := client.GetKinds()
+	requestBuilder := client.client.R()
 	kind, ok := kinds[resource.Kind]
 	if !ok {
 		return fmt.Errorf("kind %s not found", resource.Kind)
 	}
-	deletePath, err := kind.DeletePath(resource)
+	deletePath, queryParams, err := kind.DeletePath(resource)
 	if err != nil {
 		return err
 	}
 	url := client.baseUrl + deletePath
-	resp, err := client.client.R().Delete(url)
+	if queryParams != nil {
+		requestBuilder = requestBuilder.SetQueryParams(queryParams)
+	}
+	resp, err := requestBuilder.Delete(url)
 	if err != nil {
 		return err
 	} else if resp.IsError() {

--- a/client/console_client_test.go
+++ b/client/console_client_test.go
@@ -526,6 +526,44 @@ func TestDeleteResourceShouldWork(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestDeleteResourceWhenMetadataContainsQueryParameter(t *testing.T) {
+	defer httpmock.Reset()
+	baseUrl := "http://baseUrl"
+	apiKey := "aToken"
+	client, err := Make(ApiParameter{
+		ApiKey:  apiKey,
+		BaseUrl: baseUrl,
+	})
+	if err != nil {
+		panic(err)
+	}
+	httpmock.ActivateNonDefault(
+		client.client.GetClient(),
+	)
+	responder, err := httpmock.NewJsonResponder(200, "[]")
+	if err != nil {
+		panic(err)
+	}
+
+	httpmock.RegisterMatcherResponderWithQuery(
+		"DELETE",
+		"http://baseUrl/api/public/monitoring/v3/alert/alert1",
+		"group=admin",
+		httpmock.HeaderIs("Authorization", "Bearer "+apiKey).
+			And(httpmock.HeaderIs("X-CDK-CLIENT", "CLI/unknown")),
+		responder,
+	)
+
+	resource, err := resource.FromYamlByte([]byte(`{"apiVersion":"v3","kind":"Alert","metadata":{"name":"alert1","group":"admin"},"spec":{}}`), true)
+	if err != nil {
+		t.Error(err)
+	}
+	err = client.DeleteResource(&resource[0])
+	if err != nil {
+		t.Error(err)
+	}
+}
 func TestDeleteShouldFailOnNot2XX(t *testing.T) {
 	defer httpmock.Reset()
 	baseUrl := "http://baseUrl"

--- a/client/gateway_client.go
+++ b/client/gateway_client.go
@@ -136,16 +136,20 @@ func (client *GatewayClient) Delete(kind *schema.Kind, parentPathValue []string,
 
 func (client *GatewayClient) DeleteResourceByName(resource *resource.Resource) error {
 	kinds := client.GetKinds()
+	requestBuilder := client.client.R()
 	kind, ok := kinds[resource.Kind]
 	if !ok {
 		return fmt.Errorf("kind %s not found", resource.Kind)
 	}
-	deletePath, err := kind.DeletePath(resource)
+	deletePath, queryParams, err := kind.DeletePath(resource)
 	if err != nil {
 		return err
 	}
 	url := client.baseUrl + deletePath
-	resp, err := client.client.R().Delete(url)
+	if queryParams != nil {
+		requestBuilder = requestBuilder.SetQueryParams(queryParams)
+	}
+	resp, err := requestBuilder.Delete(url)
 	if err != nil {
 		return err
 	} else if resp.IsError() {
@@ -222,7 +226,7 @@ func (client *GatewayClient) DeleteResourceInterceptors(resource *resource.Resou
 	if !ok {
 		return fmt.Errorf("kind %s not found", resource.Kind)
 	}
-	deletePath, err := kind.DeletePath(resource)
+	deletePath, _, err := kind.DeletePath(resource)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- The CLI wasn't parsing the yml file correctly.
- The query params wouldn't be extracted, which would cause the delete to fail, as the Owner wasn't specified. 
- FIX: Extract query params from file metadata and include in the delete request